### PR TITLE
fix: add MatchId to the allocate payload by bumping the API's package version

### DIFF
--- a/modules/AgonesAllocator/Project/AgonesAllocator.csproj
+++ b/modules/AgonesAllocator/Project/AgonesAllocator.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Com.Unity.Services.CloudCode.Apis" Version="0.0.23" />
+      <PackageReference Include="Com.Unity.Services.CloudCode.Apis" Version="0.0.24" />
       <PackageReference Include="Com.Unity.Services.CloudCode.Core" Version="0.0.3" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
       <PackageReference Include="Microsoft.Kiota.Bundle" Version="1.21.1" />

--- a/modules/GameLiftAllocator/Project/GameLiftAllocator.csproj
+++ b/modules/GameLiftAllocator/Project/GameLiftAllocator.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Com.Unity.Services.CloudCode.Apis" Version="0.0.23" />
+      <PackageReference Include="Com.Unity.Services.CloudCode.Apis" Version="0.0.24" />
       <PackageReference Include="Com.Unity.Services.CloudCode.Core" Version="0.0.3" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
       <PackageReference Include="AWSSDK.GameLift" Version="3.7.*" />

--- a/modules/MultiplayAllocator/Project/MultiplayAllocator.csproj
+++ b/modules/MultiplayAllocator/Project/MultiplayAllocator.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Com.Unity.Services.CloudCode.Core" Version="0.0.3" />
-      <PackageReference Include="Com.Unity.Services.CloudCode.Apis" Version="0.0.23" />
+      <PackageReference Include="Com.Unity.Services.CloudCode.Apis" Version="0.0.24" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     </ItemGroup>
 

--- a/modules/PlayFabAllocator/Project/PlayFabAllocator.csproj
+++ b/modules/PlayFabAllocator/Project/PlayFabAllocator.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Com.Unity.Services.CloudCode.Apis" Version="0.0.23" />
+    <PackageReference Include="Com.Unity.Services.CloudCode.Apis" Version="0.0.24" />
     <PackageReference Include="Com.Unity.Services.CloudCode.Core" Version="0.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/tests/AllocatorTests/AgonesAllocatorTests.cs
+++ b/tests/AllocatorTests/AgonesAllocatorTests.cs
@@ -53,7 +53,7 @@ public class AgonesAllocatorTests
             });
         
         var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new())));
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new())));
         
         Assert.That(allocation.Status, Is.EqualTo(AllocateStatus.Created));
         Assert.That(allocation.Message, Is.Null);

--- a/tests/AllocatorTests/GameLiftAllocatorTests.cs
+++ b/tests/AllocatorTests/GameLiftAllocatorTests.cs
@@ -46,7 +46,7 @@ public class GameLiftAllocatorTests
             });
         
         var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new())));
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new())));
 
         Assert.That(allocation.Status, Is.EqualTo(AllocateStatus.Created));
         Assert.That(allocation.Message, Is.Null);
@@ -69,7 +69,7 @@ public class GameLiftAllocatorTests
             });
         
         var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new
             Dictionary<string, object>{
                 {"region", "customRegion"},
             })));

--- a/tests/AllocatorTests/MultiplayAllocatorTests.cs
+++ b/tests/AllocatorTests/MultiplayAllocatorTests.cs
@@ -41,7 +41,7 @@ public class MultiplayAllocatorTests
             });
         
         var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new())));
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new())));
 
         Assert.That(allocation.Status, Is.EqualTo(AllocateStatus.Created));
         Assert.That(allocation.Message, Is.Null);

--- a/tests/AllocatorTests/PlayFabAllocatorTests.cs
+++ b/tests/AllocatorTests/PlayFabAllocatorTests.cs
@@ -45,7 +45,7 @@ public class PlayFabAllocatorTests
             .ThrowsAsync(new Exception("Secret not found."));
 
          var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new Dictionary<string, object>())));
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new Dictionary<string, object>())));
 
         using (Assert.EnterMultipleScope())
         {
@@ -61,7 +61,7 @@ public class PlayFabAllocatorTests
         _authenticationApiMock.Setup(a => a.GetEntityTokenAsync(It.IsAny<PlayFabApiSettings>())).Throws<Exception>();
 
         var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new Dictionary<string, object>())));
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new Dictionary<string, object>())));
 
         using (Assert.EnterMultipleScope())
         {
@@ -141,7 +141,7 @@ public class PlayFabAllocatorTests
             .ReturnsAsync(tokenResponse);
 
         var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new Dictionary<string, object>())));
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new Dictionary<string, object>())));
 
         using (Assert.EnterMultipleScope())
         {
@@ -181,7 +181,7 @@ public class PlayFabAllocatorTests
             .ReturnsAsync(allocationResult);
 
         var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new Dictionary<string, object>())));
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new Dictionary<string, object>())));
 
         using (Assert.EnterMultipleScope())
         {
@@ -214,7 +214,7 @@ public class PlayFabAllocatorTests
             });
 
         var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new Dictionary<string, object>())));
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new Dictionary<string, object>())));
 
         using (Assert.EnterMultipleScope())
         {
@@ -254,7 +254,7 @@ public class PlayFabAllocatorTests
             });
 
         var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new Dictionary<string, object>
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new Dictionary<string, object>
             {
                 { "region", "customRegion" }
             })));
@@ -297,7 +297,7 @@ public class PlayFabAllocatorTests
             });
 
         var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
-            new MatchmakingResults(null, "poolId", "poolName", "queueName", new Dictionary<string, object>
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new Dictionary<string, object>
             {
                 { "region", string.Empty }
             })));


### PR DESCRIPTION
# Pull Request

## Description
Adding MatchId to the allocation payload by updating to the lasted API's package. 

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security fix
- [ ] Performance improvement

## Provider Integration
<!-- Which provider integration does this affect? -->
- [ ] GameLift
- [X] Multiplay
- [ ] PlayFab
- [ ] New Provider Integration
- [ ] General/Infrastructure
- [ ] Documentation

## Changes Made
<!-- List the specific changes you've made -->
- Updated library

## Testing
<!-- Describe how you tested your changes -->
- [X] Tested locally
- [X] Tested with actual provider integration
- [C] Added/updated unit tests
- [ ] Verified no breaking changes

## Security Checklist
<!-- CRITICAL: Verify all security requirements -->
- [X] No credentials, API keys, or secrets committed
- [X] Ran secret scan before committing
- [X] Reviewed all changes for sensitive data
- [X] Updated .gitignore if needed
- [X] Followed security best practices from SECURITY.md

## License Agreement
<!-- REQUIRED: Acknowledge license terms -->
- [X] I agree to license my contributions under the Unity Companion License
- [X] I understand that Unity retains all rights to contributed code as specified in the license
- [X] I have read and agree to the terms in CONTRIBUTING.md

## Additional Notes
<!-- Any additional information reviewers should know -->

