### PR TITLE
fix: location of build configuration ID

### DIFF
--- a/modules/MultiplayAllocator/CONFIGURATION.md
+++ b/modules/MultiplayAllocator/CONFIGURATION.md
@@ -22,7 +22,7 @@ Replace with your Unity Multiplay fleet ID from the [Unity Dashboard](https://cl
 private const int BuildConfigId = 0;
 ```
 
-Replace with your build configuration ID from Multiplay under **Builds**.
+Replace with your build configuration ID from Multiplay under **Build Configurations**.
 
 ### DefaultRegion (line 27)
 


### PR DESCRIPTION
# Pull Request

## Description
The Build Configuration ID is different from the Build ID and is found on the Build Configurations page, not the Builds page.

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Security fix
- [ ] Performance improvement

## Provider Integration
<!-- Which provider integration does this affect? -->
- [ ] GameLift
- [x] Multiplay
- [ ] PlayFab
- [ ] New Provider Integration
- [ ] General/Infrastructure
- [ ] Documentation

## Changes Made
<!-- List the specific changes you've made -->
- Updated CONFIGURATION.md for MultiplayAllocator

## License Agreement
<!-- REQUIRED: Acknowledge license terms -->
- [x] I agree to license my contributions under the Unity Companion License
- [x] I understand that Unity retains all rights to contributed code as specified in the license
- [x] I have read and agree to the terms in CONTRIBUTING.md