### PR TITLE
feat(gameye): add GameyeAllocator module

### DIFF
--- a/modules/GameyeAllocator/CONFIGURATION.md
+++ b/modules/GameyeAllocator/CONFIGURATION.md
@@ -1,0 +1,40 @@
+# Gameye Allocator Configuration
+
+## Prerequisites
+
+Refer to the [Gameye Getting Started guide](https://www.gameye.com/docs/getting-started/) to set up your account, Docker Hub registry, and application in the Gameye Admin Panel.
+
+## Secrets
+
+Add the following secret in the Unity Dashboard under **Administration > Secrets**:
+
+| Secret Name | Description |
+|---|---|
+| `GAMEYE_API_TOKEN` | Your Gameye API bearer token. Obtain this from your Gameye account or by contacting Gameye support. |
+
+## Code Configuration
+
+Update the following constants in `Project/GameyeAllocator.cs`:
+
+### `ImageName` (line 25)
+
+Set this to the name of your application image as configured in the Gameye Admin Panel. This must match the image name you registered during setup.
+
+### `DefaultLocation` (line 26)
+
+Set this to your preferred default deployment region (e.g. `"europe"`, `"north-america"`). See [available locations](https://www.gameye.com/docs/api-v2/available-locations/) for the full list.
+
+### `GamePort` (line 27)
+
+Set this to the container port your game server listens on (e.g. `7777`). This must match the port exposed in your Dockerfile and configured in the Gameye Admin Panel.
+
+## How It Works
+
+Unlike other allocators that require a separate poll step, Gameye returns the host IP and port synchronously in the allocation response. The poll method is implemented for compatibility with Unity Matchmaker's allocation flow but will typically resolve on the first call.
+
+## Resources
+
+- [Gameye Documentation](https://www.gameye.com/docs/)
+- [Session API Reference](https://www.gameye.com/docs/api-v2/reference/post-session/)
+- [Available Locations](https://www.gameye.com/docs/api-v2/available-locations/)
+- [Gameye Discord](https://discord.com/invite/QvJ3KH5max)

--- a/modules/GameyeAllocator/GameyeAllocator.sln
+++ b/modules/GameyeAllocator/GameyeAllocator.sln
@@ -1,0 +1,42 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Project", "Project", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameyeAllocator", "Project\GameyeAllocator.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|x64.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|x86.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|x64.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|x64.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|x86.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C3D4E5F6-A7B8-9012-CDEF-123456789012}
+	EndGlobalSection
+EndGlobal

--- a/modules/GameyeAllocator/Project/Client/GameyeClient.cs
+++ b/modules/GameyeAllocator/Project/Client/GameyeClient.cs
@@ -1,0 +1,18 @@
+using System.Net.Http;
+
+namespace GameyeAllocatorModule.Client;
+
+public interface IGameyeHttpClientFactory
+{
+	HttpClient Create(string apiToken);
+}
+
+public class GameyeHttpClientFactory : IGameyeHttpClientFactory
+{
+	public HttpClient Create(string apiToken)
+	{
+		var client = new HttpClient();
+		client.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiToken}");
+		return client;
+	}
+}

--- a/modules/GameyeAllocator/Project/Client/Models/SessionRequest.cs
+++ b/modules/GameyeAllocator/Project/Client/Models/SessionRequest.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace GameyeAllocatorModule.Client.Models;
+
+public class SessionRequest
+{
+	[JsonProperty("id")]
+	public string? Id { get; set; }
+
+	[JsonProperty("location")]
+	public required string Location { get; set; }
+
+	[JsonProperty("image")]
+	public required string Image { get; set; }
+
+	[JsonProperty("env")]
+	public Dictionary<string, string>? Env { get; set; }
+
+	[JsonProperty("args")]
+	public List<string>? Args { get; set; }
+
+	[JsonProperty("labels")]
+	public Dictionary<string, string>? Labels { get; set; }
+
+	[JsonProperty("restart")]
+	public bool Restart { get; set; }
+
+	[JsonProperty("ttl")]
+	public int? Ttl { get; set; }
+}

--- a/modules/GameyeAllocator/Project/Client/Models/SessionResponse.cs
+++ b/modules/GameyeAllocator/Project/Client/Models/SessionResponse.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace GameyeAllocatorModule.Client.Models;
+
+public class SessionResponse
+{
+	[JsonProperty("id")]
+	public required string Id { get; set; }
+
+	[JsonProperty("host")]
+	public string? Host { get; set; }
+
+	[JsonProperty("ports")]
+	public List<PortMapping>? Ports { get; set; }
+
+	[JsonProperty("status")]
+	public string? Status { get; set; }
+}
+
+public class PortMapping
+{
+	[JsonProperty("type")]
+	public string? Type { get; set; }
+
+	[JsonProperty("container")]
+	public int Container { get; set; }
+
+	[JsonProperty("host")]
+	public int Host { get; set; }
+}

--- a/modules/GameyeAllocator/Project/GameyeAllocator.cs
+++ b/modules/GameyeAllocator/Project/GameyeAllocator.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using GameyeAllocatorModule.Client;
+using GameyeAllocatorModule.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Unity.Services.CloudCode.Apis;
+using Unity.Services.CloudCode.Apis.Matchmaker;
+using Unity.Services.CloudCode.Core;
+using IExecutionContext = Unity.Services.CloudCode.Core.IExecutionContext;
+
+namespace GameyeAllocatorModule;
+
+/// <summary>
+/// Module configuration for dependency injection.
+/// Registers IGameApiClient as a singleton for accessing Unity services like Secret Manager.
+/// </summary>
+public class ModuleConfig : ICloudCodeSetup
+{
+	public void Setup(ICloudCodeConfig config)
+	{
+		config.Dependencies.AddSingleton(GameApiClient.Create());
+		config.Dependencies.AddScoped<IGameyeHttpClientFactory, GameyeHttpClientFactory>();
+	}
+}
+
+public class GameyeAllocator(IGameApiClient gameApiClient, IGameyeHttpClientFactory httpClientFactory, ILogger<GameyeAllocator> logger) : IMatchmakerAllocator
+{
+	// Configuration - users should modify these constants for their setup
+	private const string ImageName = "MyGame"; // TODO: Replace with your Gameye application image name
+	private const string DefaultLocation = "europe"; // TODO: Replace with your preferred region
+	private const int GamePort = 7777; // TODO: Replace with your game server port
+
+	// Gameye Constants
+	private const string GameyeApiUrl = "https://api.gameye.io";
+
+	// Secret names - these must match the secrets stored in Unity Dashboard
+	private const string GameyeApiTokenSecretName = "GAMEYE_API_TOKEN";
+
+	[CloudCodeFunction("Matchmaker_AllocateServer")]
+	public async Task<AllocateResponse> Allocate(IExecutionContext context, AllocateRequest request)
+	{
+		try
+		{
+			Secret gameyeApiToken = await gameApiClient.SecretManager.GetSecret(context, GameyeApiTokenSecretName);
+			using HttpClient client = httpClientFactory.Create(gameyeApiToken.Value);
+
+			var sessionRequest = new SessionRequest
+			{
+				Id = request.MatchId,
+				Location = DefaultLocation,
+				Image = ImageName,
+				Env = new Dictionary<string, string>
+				{
+					{ "MATCH_ID", request.MatchId },
+				},
+				Labels = new Dictionary<string, string>
+				{
+					{ "matchmaker", "unity" },
+					{ "pool", request.MatchmakingResults.PoolName ?? "" },
+				},
+			};
+
+			var content = new StringContent(JsonConvert.SerializeObject(sessionRequest), Encoding.UTF8, "application/json");
+			HttpResponseMessage response = await client.PostAsync($"{GameyeApiUrl}/session", content);
+
+			string responseContent = await response.Content.ReadAsStringAsync();
+			if (!response.IsSuccessStatusCode)
+			{
+				logger.LogError("Gameye session creation failed with status code {ResponseStatusCode}: {ResponseContent}", response.StatusCode, responseContent);
+				return new AllocateResponse(AllocateStatus.Error)
+				{
+					Message = responseContent,
+				};
+			}
+
+			var sessionResponse = JsonConvert.DeserializeObject<SessionResponse>(responseContent);
+
+			return new AllocateResponse(AllocateStatus.Created)
+			{
+				AllocationData = new Dictionary<string, object>
+				{
+					{ "sessionId", sessionResponse?.Id ?? request.MatchId },
+					{ "host", sessionResponse?.Host ?? string.Empty },
+					{ "port", FindGamePort(sessionResponse?.Ports) },
+				},
+			};
+		}
+		catch (Exception e)
+		{
+			logger.LogError(e, "Gameye session creation failed");
+			return new AllocateResponse(AllocateStatus.Error)
+			{
+				Message = e.Message,
+			};
+		}
+	}
+
+	[CloudCodeFunction("Matchmaker_PollAllocation")]
+	public async Task<PollResponse> Poll(IExecutionContext context, PollRequest request)
+	{
+		var sessionId = request.AllocationData["sessionId"].ToString();
+
+		// Gameye returns host and port synchronously on allocation.
+		// If we already have connection data, return it immediately.
+		if (request.AllocationData.TryGetValue("host", out var hostObj) &&
+		    request.AllocationData.TryGetValue("port", out var portObj))
+		{
+			var host = hostObj?.ToString();
+			var port = Convert.ToInt32(portObj);
+
+			if (!string.IsNullOrEmpty(host) && port > 0)
+			{
+				return new PollResponse(PollStatus.Allocated)
+				{
+					AssignmentData = AssignmentData.IpPort(host, port),
+				};
+			}
+		}
+
+		// Fallback: query the session status from the Gameye API
+		try
+		{
+			Secret gameyeApiToken = await gameApiClient.SecretManager.GetSecret(context, GameyeApiTokenSecretName);
+			using HttpClient client = httpClientFactory.Create(gameyeApiToken.Value);
+			HttpResponseMessage response = await client.GetAsync($"{GameyeApiUrl}/session/{sessionId}");
+			string responseContent = await response.Content.ReadAsStringAsync();
+
+			if (!response.IsSuccessStatusCode)
+			{
+				return new PollResponse(PollStatus.Error)
+				{
+					Message = responseContent,
+				};
+			}
+
+			var sessionResponse = JsonConvert.DeserializeObject<SessionResponse>(responseContent);
+
+			if (sessionResponse == null)
+			{
+				return new PollResponse(PollStatus.Error)
+				{
+					Message = "Session response is null",
+				};
+			}
+
+			return sessionResponse.Status?.ToLowerInvariant() switch
+			{
+				"running" => new PollResponse(PollStatus.Allocated)
+				{
+					AssignmentData = AssignmentData.IpPort(
+						sessionResponse.Host ?? string.Empty,
+						FindGamePort(sessionResponse.Ports)
+					),
+				},
+				"created" or "restarting" => new PollResponse(PollStatus.Pending),
+				"exited" or "dead" => new PollResponse(PollStatus.Error)
+				{
+					Message = $"Session {sessionId} is in state: {sessionResponse.Status}",
+				},
+				_ => new PollResponse(PollStatus.Pending),
+			};
+		}
+		catch (Exception e)
+		{
+			logger.LogError(e, "Error polling Gameye session {SessionId}", sessionId);
+			return new PollResponse(PollStatus.Error)
+			{
+				Message = e.Message,
+			};
+		}
+	}
+
+	/// <summary>
+	/// Finds the host port mapped to the configured game port from the session's port mappings.
+	/// Falls back to the first available port if the configured port is not found.
+	/// </summary>
+	private static int FindGamePort(List<PortMapping>? ports)
+	{
+		if (ports == null || ports.Count == 0)
+			return 0;
+
+		var match = ports.FirstOrDefault(p => p.Container == GamePort);
+		return match?.Host ?? ports[0].Host;
+	}
+}

--- a/modules/GameyeAllocator/Project/GameyeAllocator.csproj
+++ b/modules/GameyeAllocator/Project/GameyeAllocator.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <Configurations>Debug;Release</Configurations>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Com.Unity.Services.CloudCode.Apis" Version="0.0.24" />
+      <PackageReference Include="Com.Unity.Services.CloudCode.Core" Version="0.0.3" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    </ItemGroup>
+
+    <PropertyGroup>
+        <PublishReadyToRunComposite>true</PublishReadyToRunComposite>
+    </PropertyGroup>
+</Project>

--- a/modules/GameyeAllocator/Project/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/modules/GameyeAllocator/Project/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net5.0\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net5.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+  </PropertyGroup>
+</Project>

--- a/tests/AllocatorTests/AllocatorTests.csproj
+++ b/tests/AllocatorTests/AllocatorTests.csproj
@@ -26,5 +26,6 @@
         <ProjectReference Include="..\..\modules\PlayFabAllocator\Project\PlayFabAllocator.csproj"/>
         <ProjectReference Include="..\..\modules\EdgegapAllocator\Project\EdgegapAllocator.csproj"/>
         <ProjectReference Include="..\..\modules\RocketScienceAllocator\Project\RocketScienceAllocator.csproj"/>
+        <ProjectReference Include="..\..\modules\GameyeAllocator\Project\GameyeAllocator.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/AllocatorTests/GameyeAllocatorTests.cs
+++ b/tests/AllocatorTests/GameyeAllocatorTests.cs
@@ -1,0 +1,219 @@
+using GameyeAllocatorModule;
+using GameyeAllocatorModule.Client;
+using GameyeAllocatorModule.Client.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Unity.Services.CloudCode.Apis;
+using Unity.Services.CloudCode.Apis.Matchmaker;
+using Unity.Services.CloudCode.Core;
+using MatchmakingResults = Unity.Services.CloudCode.Apis.Matchmaker.MatchmakingResults;
+
+namespace AllocatorTests;
+
+public class GameyeAllocatorTests
+{
+	private readonly Mock<ILogger<GameyeAllocator>> _loggerMock = new();
+	private readonly Mock<IGameyeHttpClientFactory> _httpClientFactoryMock = new();
+	private readonly Mock<ISecretClient> _secretClientMock = new();
+	private readonly Mock<IGameApiClient> _gameClientMock = new();
+	private readonly Mock<HttpMessageHandler> _httpMessageHandlerMock = new();
+
+	private readonly Mock<IExecutionContext> _executionContextMock = new();
+
+	private readonly GameyeAllocator _allocator;
+
+	public GameyeAllocatorTests()
+	{
+		_gameClientMock.SetupGet(g => g.SecretManager).Returns(_secretClientMock.Object);
+		_secretClientMock.Setup(s => s.GetSecret(_executionContextMock.Object, It.IsAny<string>()))
+			.ReturnsAsync(new Secret("secret"));
+		_httpClientFactoryMock.Setup(f => f.Create(It.IsAny<string>()))
+			.Returns(() => new HttpClient(_httpMessageHandlerMock.Object));
+		_allocator = new GameyeAllocator(_gameClientMock.Object, _httpClientFactoryMock.Object, _loggerMock.Object);
+	}
+
+	[Test]
+	public async Task TestGameyeCanAllocate()
+	{
+		_httpMessageHandlerMock.Reset();
+		_httpMessageHandlerMock
+			.Protected()
+			.Setup<Task<HttpResponseMessage>>(
+				"SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.ReturnsAsync(new HttpResponseMessage()
+			{
+				StatusCode = System.Net.HttpStatusCode.Created,
+				Content = new StringContent(
+					"""
+					{
+					  "id": "test-session-id",
+					  "host": "203.0.113.42",
+					  "ports": [
+					    { "type": "udp", "container": 7777, "host": 49152 }
+					  ]
+					}
+					"""
+				),
+			});
+
+		var allocation = await _allocator.Allocate(_executionContextMock.Object,
+			new AllocateRequest("match-1234",
+				new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new())));
+
+		Assert.That(allocation.Status, Is.EqualTo(AllocateStatus.Created));
+		Assert.That(allocation.Message, Is.Null);
+		Assert.That(allocation.AllocationData, Is.Not.Null);
+		Assert.That(allocation.AllocationData["sessionId"], Is.EqualTo("test-session-id"));
+		Assert.That(allocation.AllocationData["host"], Is.EqualTo("203.0.113.42"));
+		Assert.That(allocation.AllocationData["port"], Is.EqualTo(49152));
+	}
+
+	[Test]
+	public async Task TestGameyeCanAllocateWithMatchMetadata()
+	{
+		HttpRequestMessage? capturedRequest = null;
+		_httpMessageHandlerMock.Reset();
+		_httpMessageHandlerMock
+			.Protected()
+			.Setup<Task<HttpResponseMessage>>(
+				"SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+			{
+				capturedRequest = req;
+			})
+			.ReturnsAsync(new HttpResponseMessage()
+			{
+				StatusCode = System.Net.HttpStatusCode.Created,
+				Content = new StringContent(
+					"""
+					{
+					  "id": "match-1234",
+					  "host": "203.0.113.42",
+					  "ports": [
+					    { "type": "udp", "container": 7777, "host": 49152 }
+					  ]
+					}
+					"""
+				),
+			});
+
+		var allocation = await _allocator.Allocate(_executionContextMock.Object,
+			new AllocateRequest("match-1234",
+				new MatchmakingResults(null, "matchId", "poolId", "testPool", "queueName", new())));
+
+		Assert.That(allocation.Status, Is.EqualTo(AllocateStatus.Created));
+
+		// Verify the request body sent to Gameye
+		Assert.That(capturedRequest, Is.Not.Null);
+		Assert.That(capturedRequest!.Content, Is.Not.Null);
+
+		var body = await capturedRequest.Content!.ReadAsStringAsync();
+		var sessionRequest = JsonConvert.DeserializeObject<SessionRequest>(body);
+
+		Assert.That(sessionRequest, Is.Not.Null);
+		Assert.That(sessionRequest!.Image, Is.EqualTo("MyGame"));
+		Assert.That(sessionRequest.Location, Is.EqualTo("europe"));
+		Assert.That(sessionRequest.Id, Is.EqualTo("match-1234"));
+		Assert.That(sessionRequest.Env, Is.Not.Null);
+		Assert.That(sessionRequest.Env!["MATCH_ID"], Is.EqualTo("match-1234"));
+		Assert.That(sessionRequest.Labels, Is.Not.Null);
+		Assert.That(sessionRequest.Labels!["matchmaker"], Is.EqualTo("unity"));
+		Assert.That(sessionRequest.Labels["pool"], Is.EqualTo("testPool"));
+	}
+
+	[Test]
+	public async Task TestGameyePollReturnsAllocatedFromCachedData()
+	{
+		// Gameye returns host/port synchronously, so Poll should resolve from AllocationData
+		var poll = await _allocator.Poll(_executionContextMock.Object,
+			new PollRequest("match-1234",
+				new Dictionary<string, object>
+				{
+					{ "sessionId", "test-session-id" },
+					{ "host", "203.0.113.42" },
+					{ "port", 49152 },
+				},
+				DateTimeOffset.UtcNow));
+
+		Assert.That(poll.Status, Is.EqualTo(PollStatus.Allocated));
+		Assert.That(poll.Message, Is.Null);
+		Assert.That(poll.AssignmentData, Is.Not.Null);
+		Assert.That(poll.AssignmentData.Type, Is.EqualTo(AssignmentType.IpPort));
+		Assert.That(poll.AssignmentData.Ip, Is.EqualTo("203.0.113.42"));
+		Assert.That(poll.AssignmentData.Port, Is.EqualTo(49152));
+	}
+
+	[Test]
+	public async Task TestGameyePollFallsBackToApi()
+	{
+		_httpMessageHandlerMock.Reset();
+		_httpMessageHandlerMock
+			.Protected()
+			.Setup<Task<HttpResponseMessage>>(
+				"SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.ReturnsAsync(new HttpResponseMessage
+			{
+				Content = new StringContent(
+					"""
+					{
+					  "id": "test-session-id",
+					  "host": "203.0.113.42",
+					  "ports": [
+					    { "type": "udp", "container": 7777, "host": 49152 }
+					  ],
+					  "status": "running"
+					}
+					"""
+				),
+			});
+
+		// Simulate missing host/port in allocation data (edge case)
+		var poll = await _allocator.Poll(_executionContextMock.Object,
+			new PollRequest("match-1234",
+				new Dictionary<string, object>
+				{
+					{ "sessionId", "test-session-id" },
+					{ "host", "" },
+					{ "port", 0 },
+				},
+				DateTimeOffset.UtcNow));
+
+		Assert.That(poll.Status, Is.EqualTo(PollStatus.Allocated));
+		Assert.That(poll.AssignmentData, Is.Not.Null);
+		Assert.That(poll.AssignmentData.Ip, Is.EqualTo("203.0.113.42"));
+		Assert.That(poll.AssignmentData.Port, Is.EqualTo(49152));
+	}
+
+	[Test]
+	public async Task TestGameyeAllocationError()
+	{
+		_httpMessageHandlerMock.Reset();
+		_httpMessageHandlerMock
+			.Protected()
+			.Setup<Task<HttpResponseMessage>>(
+				"SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.ReturnsAsync(new HttpResponseMessage()
+			{
+				StatusCode = System.Net.HttpStatusCode.NotFound,
+				Content = new StringContent("Location not found"),
+			});
+
+		var allocation = await _allocator.Allocate(_executionContextMock.Object,
+			new AllocateRequest("match-1234",
+				new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new())));
+
+		Assert.That(allocation.Status, Is.EqualTo(AllocateStatus.Error));
+		Assert.That(allocation.Message, Is.Not.Null);
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `GameyeAllocator` Cloud Code module for allocating [Gameye](https://gameye.com) game server sessions from Unity Matchmaker.

### Key characteristics

- **Synchronous allocation:** Gameye's `POST /session` returns the host IP and port immediately in the response — the poll method resolves on the first call in most cases
- **No game server SDK:** Gameye requires no SDK integration in the game server binary. Studios ship a Docker container and call a REST API
- **Bearer token authentication** via Unity Secret Manager (`GAMEYE_API_TOKEN`)
- **Match metadata** passed to the game server via environment variables and container labels

### Files

| File | Purpose |
|---|---|
| `modules/GameyeAllocator/CONFIGURATION.md` | Setup guide (secrets, constants, resources) |
| `modules/GameyeAllocator/GameyeAllocator.sln` | Solution file |
| `modules/GameyeAllocator/Project/GameyeAllocator.cs` | Allocate + Poll implementations |
| `modules/GameyeAllocator/Project/GameyeAllocator.csproj` | Project file (net9.0, same deps as other modules) |
| `modules/GameyeAllocator/Project/Client/GameyeClient.cs` | HTTP client factory with Bearer auth |
| `modules/GameyeAllocator/Project/Client/Models/SessionRequest.cs` | POST /session request model |
| `modules/GameyeAllocator/Project/Client/Models/SessionResponse.cs` | Session response model (id, host, ports) |
| `tests/AllocatorTests/GameyeAllocatorTests.cs` | Unit tests (allocate, poll, metadata, errors) |
| `tests/AllocatorTests/AllocatorTests.csproj` | Added project reference |

### How it works

1. **Allocate:** Retrieves API token from Secret Manager, posts a session request to `https://api.gameye.io/session` with location, image name, match ID, and pool labels. Returns session ID, host, and port in `AllocationData`.

2. **Poll:** Checks if host/port are already in `AllocationData` (from the synchronous allocate response) and returns `Allocated` immediately. Falls back to `GET /session/{id}` if connection data is missing.

### Configuration

One secret (`GAMEYE_API_TOKEN`) and three constants (`ImageName`, `DefaultLocation`, `GamePort`) — documented in `CONFIGURATION.md`.

### Testing

5 unit tests covering:
- Successful allocation with connection data
- Request body verification (image, location, env, labels)
- Poll resolving from cached allocation data (no API call)
- Poll falling back to API query
- Allocation error handling