### PR TITLE
feat(rocketscience): adds error logging on poll failure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,14 +13,15 @@ assignees: ''
 <!-- Which provider integration is affected? -->
 - [ ] GameLift
 - [ ] Multiplay
+- [ ] Multiplay by Rocket Science
 - [ ] PlayFab
 - [ ] Other (please specify)
 
 ## Steps to Reproduce
 <!-- Provide detailed steps to reproduce the issue -->
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 ## Expected Behavior
 <!-- What did you expect to happen? -->
@@ -29,10 +30,10 @@ assignees: ''
 <!-- What actually happened? -->
 
 ## Environment
-- Unity Version: 
-- UGS CLI Version: 
-- .NET SDK Version: 
-- Operating System: 
+- Unity Version:
+- UGS CLI Version:
+- .NET SDK Version:
+- Operating System:
 
 ## Additional Context
 <!-- Add any other context, logs, or screenshots about the problem here -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,6 +19,7 @@ assignees: ''
 <!-- Which provider integration would this affect? -->
 - [ ] GameLift
 - [ ] Multiplay
+- [ ] Multiplay by Rocket Science
 - [ ] PlayFab
 - [ ] New Provider Integration
 - [ ] General/All

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -13,6 +13,7 @@ assignees: ''
 <!-- Which provider integration is your question about? -->
 - [ ] GameLift
 - [ ] Multiplay
+- [ ] Multiplay by Rocket Science
 - [ ] PlayFab
 - [ ] General
 

--- a/modules/RocketScienceAllocator/Project/RocketScienceAllocator.cs
+++ b/modules/RocketScienceAllocator/Project/RocketScienceAllocator.cs
@@ -122,6 +122,8 @@ public class RocketScienceAllocator(IGameApiClient gameApiClient, IRocketScience
             var responseContent = await allocation.Content.ReadAsStringAsync();
             if (!allocation.IsSuccessStatusCode)
             {
+                logger.LogError("Error polling allocation {error}", responseContent);
+
                 return new PollResponse(PollStatus.Error)
                 {
                     Message = responseContent


### PR DESCRIPTION
# Pull Request

## Description
Adds an error log to the Rocket Science Allocator in the event of a non-success status code when polling for an allocation.

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security fix
- [ ] Performance improvement

## Provider Integration
<!-- Which provider integration does this affect? -->
- [ ] GameLift
- [ ] Multiplay
- [x] Multiplay by Rocket Science
- [ ] PlayFab
- [ ] New Provider Integration
- [ ] General/Infrastructure
- [ ] Documentation

## Related Issues
<!-- Link any related issues here -->
Fixes #
Relates to #

## Changes Made
<!-- List the specific changes you've made -->
- Call to LogError when `IsSuccessStatusCode` is false in the `Matchmaker_PollAllocation` function
- Adds `Multiplay by Rocket Science` to issue templates

## Testing
<!-- Describe how you tested your changes -->
- [ ] Tested locally
- [x] Tested with actual provider integration
- [ ] Added/updated unit tests
- [ ] Verified no breaking changes

## Security Checklist
<!-- CRITICAL: Verify all security requirements -->
- [x] No credentials, API keys, or secrets committed
- [x] Ran secret scan before committing
- [x] Reviewed all changes for sensitive data
- [x] Updated .gitignore if needed
- [x] Followed security best practices from SECURITY.md

## Code Provenance
<!-- REQUIRED: Certify the origin of your code -->
- [x] All code is original work created by me
- [x] I have the right to submit this code under the Unity Companion License
- [x] I did not copy code verbatim from provider documentation without attribution
- [x] No proprietary or confidential code is included
- [x] All third-party code is properly attributed and licensed

## License Agreement
<!-- REQUIRED: Acknowledge license terms -->
- [x] I agree to license my contributions under the Unity Companion License
- [x] I understand that Unity retains all rights to contributed code as specified in the license
- [x] I have read and agree to the terms in CONTRIBUTING.md

## Documentation
<!-- Have you updated relevant documentation? -->
- [ ] Updated README.md if needed
- [ ] Updated CONFIGURATION.md for affected modules
- [ ] Added/updated code comments
- [x] No documentation changes needed

## Provider Terms Compliance
<!-- Ensure your changes comply with provider terms -->
- [x] Changes do not violate provider terms of service
- [x] Changes do not encourage violation of rate limits or usage policies
- [x] Provider names used descriptively without implying endorsement
- [x] No provider logos or branding materials added

## Additional Notes
<!-- Any additional information reviewers should know -->

## Community Support Acknowledgment
- [x] I understand this is a community-driven project
- [x] I understand reviews are conducted on a best-effort basis
- [x] I am willing to address review feedback
