### PR TITLE
docs: add GameyeAllocator to README provider list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Then select the hosting provider that you want to use under `modules/<provider_n
 - **MultiplayAllocator** - Unity Multiplay integration
 - **PlayFabAllocator** - Microsoft PlayFab integration
 - **EdgegapAllocator** - Edgegap integration
+- **GameyeAllocator** - Gameye integration
 - **RocketScienceAllocator** - Multiplay by Rocket Science integration
 
 ### Configure the module
@@ -43,6 +44,7 @@ Each module contains a `CONFIGURATION.md` file with detailed instructions on upd
 - [MultiplayAllocator/CONFIGURATION.md](modules/MultiplayAllocator/CONFIGURATION.md)
 - [PlayFabAllocator/CONFIGURATION.md](modules/PlayFabAllocator/CONFIGURATION.md)
 - [EdgegapAllocator/CONFIGURATION.md](modules/EdgegapAllocator/CONFIGURATION.md)
+- [GameyeAllocator/CONFIGURATION.md](modules/GameyeAllocator/CONFIGURATION.md)
 - [RocketScienceAllocator/CONFIGURATION.md](modules/RocketScienceAllocator/CONFIGURATION.md)
 
 Once you've completed the configuration steps for your chosen provider, proceed to deploying the module.


### PR DESCRIPTION
## Summary

The `GameyeAllocator` module exists in `modules/GameyeAllocator/` but is not listed in the README. This PR adds it to:

- The **Getting started** provider list
- The **Configure the module** configuration links

No code changes — README only.