### PR TITLE
Add empty string check to region value from matchmaking results

### DIFF
--- a/modules/MultiplayAllocator/Project/MultiplayAllocator.cs
+++ b/modules/MultiplayAllocator/Project/MultiplayAllocator.cs
@@ -34,7 +34,10 @@ public class MultiplayAllocator(ILogger<MultiplayAllocator> logger, IMultiplayHt
     public async Task<AllocateResponse> Allocate(IExecutionContext context, AllocateRequest request)
     {
         var createAllocationUrl = $"https://{MultiplayHost}/v1/allocations/projects/{context.ProjectId}/environments/{context.EnvironmentId}/fleets/{FleetId}/allocations";
-        var region = request.MatchmakingResults.MatchProperties.GetValueOrDefault("Region")?.ToString() ?? DefaultRegion;
+        
+        var regionValue = request.MatchmakingResults.MatchProperties.GetValueOrDefault("Region")?.ToString();
+        // explicitly check for null or empty, as tickets without QoS may pass empty Region string value
+        var region = string.IsNullOrEmpty(regionValue) ? DefaultRegion : regionValue;        
 
         using var client = httpClientFactory.Create(context.ServiceToken);
 

--- a/modules/RocketScienceAllocator/Project/RocketScienceAllocator.cs
+++ b/modules/RocketScienceAllocator/Project/RocketScienceAllocator.cs
@@ -49,7 +49,9 @@ public class RocketScienceAllocator(IGameApiClient gameApiClient, IRocketScience
     {
         var projectId = !string.IsNullOrEmpty(RocketScienceProjectID) ? RocketScienceProjectID : context.ProjectId;
         var environmentId = !string.IsNullOrEmpty(RocketScienceEnvironmentID) ? RocketScienceEnvironmentID : context.EnvironmentId;
-        var region = request.MatchmakingResults.MatchProperties.GetValueOrDefault("Region")?.ToString() ?? DefaultRegionId;
+        var regionValue = request.MatchmakingResults.MatchProperties.GetValueOrDefault("Region")?.ToString();
+        // Explicitly check for null or empty, as tickets without QoS may pass empty Region string value
+        var region = string.IsNullOrEmpty(regionValue) ? DefaultRegionId : regionValue;
 
         var processAllocationUrl = $"{BaseUrl}/v4/projects/{projectId}/environments/{environmentId}/fleets/{FleetId}/allocations";
 

--- a/tests/AllocatorTests/MultiplayAllocatorTests.cs
+++ b/tests/AllocatorTests/MultiplayAllocatorTests.cs
@@ -48,6 +48,31 @@ public class MultiplayAllocatorTests
         Assert.That(allocation.AllocationData, Is.Not.Null);
         Assert.That(allocation.AllocationData["allocationId"], Is.EqualTo("allocationId"));
     }
+
+    [Test]
+    public async Task TestMultiplayAllocatorUsesDefaultsRegionWhenEmptyString()
+    {
+        _httpMessageHandlerMock.Reset();
+        _httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                Content = new StringContent("{'allocationId': 'allocationId'}")
+            });
+        
+        var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new
+            Dictionary<string, object>{
+                {"Region", ""},
+            })));
+        
+        Assert.That(allocation.AllocationData, Is.Not.Null);
+        Assert.That(allocation.AllocationData["region"], Is.EqualTo("your_default_region"));
+    }
     
     [Test]
     public async Task TestMultiplayCanPoll()

--- a/tests/AllocatorTests/RocketScienceAllocator.cs
+++ b/tests/AllocatorTests/RocketScienceAllocator.cs
@@ -56,6 +56,31 @@ public class RocketScienceAllocatorTests
     }
 
     [Test]
+    public async Task TestRocketScienceAllocatorUsesDefaultsRegionWhenEmptyString()
+    {
+        _httpMessageHandlerMock.Reset();
+        _httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                Content = new StringContent("{'allocationId': 'allocationId'}")
+            });
+        
+        var allocation = await _allocator.Allocate(_executionContextMock.Object, new AllocateRequest("1234",
+            new MatchmakingResults(null, "matchId", "poolId", "poolName", "queueName", new
+            Dictionary<string, object>{
+                {"Region", ""},
+            })));
+        
+        Assert.That(allocation.AllocationData, Is.Not.Null);
+        Assert.That(allocation.AllocationData["region"], Is.EqualTo("your_default_region"));
+    }
+
+    [Test]
     public async Task TestRocketScienceCanPoll()
     {
         _httpMessageHandlerMock.Reset();


### PR DESCRIPTION
explicitly check for null or empty, as tickets without QoS may pass empty Region string value

Add tests to validate when Region is "" in matchmaking results

# Pull Request

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security fix
- [ ] Performance improvement

## Provider Integration
<!-- Which provider integration does this affect? -->
- [ ] GameLift
- [x] Multiplay
- [ ] PlayFab
- [x] Multiplay by Rocket Science
- [ ] New Provider Integration
- [ ] General/Infrastructure
- [ ] Documentation 

## Changes Made
<!-- List the specific changes you've made -->
- Added explicit check to Region value IsNullOrEmpty to fallback to default region correctly when the matchmaker cannot pick a region from QoS data on tickes

## Testing
<!-- Describe how you tested your changes -->
- [ ] Tested locally
- [x] Tested with actual provider integration
- [x] Added/updated unit tests
- [ ] Verified no breaking changes

## Security Checklist
<!-- CRITICAL: Verify all security requirements -->
- [x] No credentials, API keys, or secrets committed
- [ ] Ran secret scan before committing
- [x] Reviewed all changes for sensitive data
- [ ] Updated .gitignore if needed
- [ ] Followed security best practices from SECURITY.md

## Code Provenance
<!-- REQUIRED: Certify the origin of your code -->
- [x] All code is original work created by me
- [x] I have the right to submit this code under the Unity Companion License
- [x] I did not copy code verbatim from provider documentation without attribution
- [x] No proprietary or confidential code is included
- [x] All third-party code is properly attributed and licensed

## License Agreement
<!-- REQUIRED: Acknowledge license terms -->
- [x] I agree to license my contributions under the Unity Companion License
- [x] I understand that Unity retains all rights to contributed code as specified in the license
- [x] I have read and agree to the terms in CONTRIBUTING.md

## Documentation
<!-- Have you updated relevant documentation? -->
- [ ] Updated README.md if needed
- [ ] Updated CONFIGURATION.md for affected modules
- [ ] Added/updated code comments
- [x] No documentation changes needed

## Provider Terms Compliance
<!-- Ensure your changes comply with provider terms -->
- [x] Changes do not violate provider terms of service
- [x] Changes do not encourage violation of rate limits or usage policies
- [x] Provider names used descriptively without implying endorsement
- [x] No provider logos or branding materials added

## Additional Notes
<!-- Any additional information reviewers should know -->

## Community Support Acknowledgment
- [x] I understand this is a community-driven project
- [x] I understand reviews are conducted on a best-effort basis
- [x] I am willing to address review feedback
